### PR TITLE
Introducing JWT validation on IAP token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WireGuard UI
 
-[![Build Status](https://github.com/embarkstudios/wireguard-ui/workflows/Docker%20Image%20CI/badge.svg)](https://github.com/EmbarkStudios/wireguard-ui/actions)
+[![Build Status](https://badge.buildkite.com/1e96905f9ee8e199808cd7faaf5a8600b2c1820fb30ae7903a.svg)](https://buildkite.com/embark-studios/wireguard-ui)
 [![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](https://github.com/EmbarkStudios)
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
@@ -20,7 +20,7 @@ A basic, self-contained management service for [WireGuard](https://wireguard.com
 
 The easiest way to run wireguard-ui is using the container image. To test it, run:
 
-```docker run --rm -it --privileged --entrypoint "/wireguard-ui" -v /tmp/wireguard-ui:/data -p 8080:8080 -p 5555:5555 embarkstudios/wireguard-ui:latest --data-dir=/data --log-level=debug```
+```docker run --rm -it --privileged --entrypoint "/wireguard-ui" -v /tmp/wireguard-ui:/data -p 8080:8080 -p 5555:5555 embarkstudios/wireguard-ui:latest --data-dir=/data --log-level=debug --no-google-auth --demo-user```
 
 When running in production, we recommend using the latest release as opposed to `latest`.
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
+	github.com/auth0-community/go-auth0 v1.0.0
 	github.com/elazarl/go-bindata-assetfs v1.0.0
 	github.com/go-bindata/go-bindata v3.1.2+incompatible // indirect
 	github.com/google/nftables v0.0.0-20190906062827-5d14089d2edc
@@ -15,4 +16,5 @@ require (
 	github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20190925195211-ef61b881e46f
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+	gopkg.in/square/go-jose.v2 v2.1.7
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafo
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/auth0-community/go-auth0 v1.0.0 h1:TqtR/xVM4E6QYXNNaZw8BdExJT1xgRF7Dgsppje+of4=
+github.com/auth0-community/go-auth0 v1.0.0/go.mod h1:cZi/9yvenqQHYLu2FOqOp/8OmP0PYyWJmD3ojOmQGYQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -46,6 +48,7 @@ github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJ
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f h1:nBX3nTcmxEtHSERBJaIo1Qa26VwRaopnZmfDQUXsF4I=
 github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
+golang.org/x/crypto v0.0.0-20180802221240-56440b844dfe/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472 h1:Gv7RPwsi3eZ2Fgewe3CBsuOebPwO27PoXzRpJPsvSSM=
 golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -74,5 +77,7 @@ golang.zx2c4.com/wireguard/wgctrl v0.0.0-20190925195211-ef61b881e46f/go.mod h1:8
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/square/go-jose.v2 v2.1.7 h1:4m8fIwX7Xdw2WlFiPJtcVCDX6ELrIdpHnRmE6Uqmktk=
+gopkg.in/square/go-jose.v2 v2.1.7/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/server.go
+++ b/server.go
@@ -32,10 +32,10 @@ import (
 var (
 	dataDir = kingpin.Flag("data-dir", "Directory used for storage").Default("/var/lib/wireguard-ui").String()
 
-	listenAddr     = kingpin.Flag("listen-address", "Address to listen to").Default(":8080").String()
-	natLink        = kingpin.Flag("nat-device", "Network interface to masquerade").Default("wlp2s0").String()
-	clientIPRange  = kingpin.Flag("client-ip-range", "Client IP CIDR").Default("172.31.255.0/24").String()
-	demoUser       = kingpin.Flag("demo-user", "Should use demo user").Default("false").Bool()
+	listenAddr    = kingpin.Flag("listen-address", "Address to listen to").Default(":8080").String()
+	natLink       = kingpin.Flag("nat-device", "Network interface to masquerade").Default("wlp2s0").String()
+	clientIPRange = kingpin.Flag("client-ip-range", "Client IP CIDR").Default("172.31.255.0/24").String()
+	demoUser      = kingpin.Flag("demo-user", "Should use demo user").Default("false").Bool()
 
 	googleAuth        = kingpin.Flag("google-auth", "Should use Google Auth").Default("true").Bool()
 	googleIAPAudience = kingpin.Flag("google-iap-audience", "IAP Audience").Default("/projects/PROJECT_NUMBER/global/backendServices/SERVICE_ID").String()

--- a/server.go
+++ b/server.go
@@ -37,8 +37,9 @@ var (
 	clientIPRange = kingpin.Flag("client-ip-range", "Client IP CIDR").Default("172.31.255.0/24").String()
 	demoUser      = kingpin.Flag("demo-user", "Should use demo user").Default("false").Bool()
 
-	googleAuth        = kingpin.Flag("google-auth", "Should use Google Auth").Default("true").Bool()
-	googleIAPAudience = kingpin.Flag("google-iap-audience", "IAP Audience").Default("/projects/PROJECT_NUMBER/global/backendServices/SERVICE_ID").String()
+	googleAuth         = kingpin.Flag("google-auth", "Should use Google Auth").Default("true").Bool()
+	googleIAPAudience  = kingpin.Flag("google-iap-audience", "IAP Audience").Default("/projects/PROJECT_NUMBER/global/backendServices/SERVICE_ID").String()
+	googleHostedDomain = kingpin.Flag("google-hosted-domain", "IAP hosted domain").Default("").String()
 
 	wgLinkName   = kingpin.Flag("wg-device-name", "WireGuard network device name").Default("wg0").String()
 	wgListenPort = kingpin.Flag("wg-listen-port", "WireGuard UDP port to listen to").Default("51820").Int()
@@ -378,7 +379,7 @@ func (s *Server) withAuth(handler httprouter.Handle) httprouter.Handle {
 				return
 			}
 
-			err = claims.Validate()
+			err = claims.Validate(*googleHostedDomain)
 			if err != nil {
 				log.Error(err.Error())
 				w.WriteHeader(http.StatusUnauthorized)

--- a/validator.go
+++ b/validator.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"errors"
+	"github.com/auth0-community/go-auth0"
+	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
+	"net/http"
+	"time"
+)
+
+const (
+	googleIAPIssuer      = "https://accounts.google.com"
+	googleJWKUrl         = "https://www.gstatic.com/iap/verify/public_key-jwk"
+	googleIAPTokenHeader = "x-goog-iap-jwt-assertion"
+)
+
+type Claims struct {
+	Subject  string `json:"sub,omitempty"`
+	Expiry   int64  `json:"exp,omitempty"`
+	Issuer   string `json:"iss,omitempty"`
+	IssuedAt int64  `json:"iat,omitempty"`
+}
+
+func NewValidator(audience string) *auth0.JWTValidator {
+	customHeaderExtractor := auth0.RequestTokenExtractorFunc(func(r *http.Request) (*jwt.JSONWebToken, error) {
+		header := r.Header.Get(googleIAPTokenHeader)
+		if header == "" {
+			return nil, auth0.ErrTokenNotFound
+		}
+
+		return jwt.ParseSigned(header)
+	})
+
+	client := auth0.NewJWKClient(auth0.JWKClientOptions{URI: googleJWKUrl}, customHeaderExtractor)
+	configuration := auth0.NewConfiguration(client, []string{audience}, googleJWKUrl, jose.RS256)
+	validator := auth0.NewValidator(configuration, customHeaderExtractor)
+
+	return validator
+}
+
+func (c *Claims) Validate() error {
+	currentTime := time.Now().Unix()
+
+	if c.Issuer != googleIAPIssuer {
+		return errors.New("invalid jwt issuer")
+	}
+
+	if currentTime > c.Expiry {
+		return errors.New("invalid expiry time")
+	}
+
+	if currentTime < c.IssuedAt {
+		return errors.New("invalid issued at")
+	}
+
+	return nil
+}

--- a/validator.go
+++ b/validator.go
@@ -10,16 +10,17 @@ import (
 )
 
 const (
-	googleIAPIssuer      = "https://accounts.google.com"
+	googleIAPIssuer      = "https://cloud.google.com/iap"
 	googleJWKUrl         = "https://www.gstatic.com/iap/verify/public_key-jwk"
 	googleIAPTokenHeader = "x-goog-iap-jwt-assertion"
 )
 
 type Claims struct {
-	Subject  string `json:"sub,omitempty"`
-	Expiry   int64  `json:"exp,omitempty"`
-	Issuer   string `json:"iss,omitempty"`
-	IssuedAt int64  `json:"iat,omitempty"`
+	Subject      string `json:"sub,omitempty"`
+	Expiry       int64  `json:"exp,omitempty"`
+	Issuer       string `json:"iss,omitempty"`
+	HostedDomain string `json:"hd,omitempty"`
+	IssuedAt     int64  `json:"iat,omitempty"`
 }
 
 func NewValidator(audience string) *auth0.JWTValidator {
@@ -39,7 +40,7 @@ func NewValidator(audience string) *auth0.JWTValidator {
 	return validator
 }
 
-func (c *Claims) Validate() error {
+func (c *Claims) Validate(hostedDomain string) error {
 	currentTime := time.Now().Unix()
 
 	if c.Issuer != googleIAPIssuer {
@@ -52,6 +53,10 @@ func (c *Claims) Validate() error {
 
 	if currentTime < c.IssuedAt {
 		return errors.New("invalid issued at")
+	}
+
+	if hostedDomain != c.HostedDomain {
+		return errors.New("invalid hosted domain")
 	}
 
 	return nil


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This PR introduces validating the JWT passed on by the Google IAP and gets the logged in email from the token (a trusted source) as opposed to trusting the header `x-goog-authenticated-user-email`. We are first validating the signature and algorithm used, to then validate the claims.

We want to validate the token to protect against the following:
* IAP is accidentally disabled;
* Misconfigured firewalls;
* Access from within the project.

Four new flags are introduced:
```
--google-auth: Enabling google auth, this is enabled by default
--demo-user: Enabling the demo user, this is disabled by default and should only be used when trying out the UI in a secure environment
--google-iap-audience: This is a specific setting to the IAP that forwards call (/projects/PROJECT_NUMBER/global/backendServices/SERVICE_ID)
--google-hosted-domain: This will typically be the email domain for the user account
```
Two new dependencies:
```
go-auth0: used to validate the signature, algorithm and to parse claims
go-jose: used in conjunction with go-auth0
```

Source: https://cloud.google.com/iap/docs/signed-headers-howto#iap_validate_jwt-java

### Related Issues
