### PR TITLE
ui: avoid "async race" with new client POST

### DIFF
--- a/ui/src/Clients.svelte
+++ b/ui/src/Clients.svelte
@@ -17,9 +17,10 @@
   async function handleNewClick(event) {
     const res = await fetch(clientsUrl, {
       method: "POST",
-    }).then(getClients());
+    });
     let newClient = await res.json();
     console.log("New client added", newClient);
+    await getClients();
   }
 
 	onMount(getClients);


### PR DESCRIPTION
The getClients() and POST request were being issued one after another
(not waiting for the POST to return). This can cause the GET /clients to
return the old list before the user config is updated. Waiting for the
POST to return before retrieving the new client list fixes the race.

This behavior can be reproduced by adding a time.Sleep(time.Second) to
the CreateClient server handler.

Not sure if there's supposed to be a .github/PULL_REQUEST_TEMPLATE.md; yes I read the code of conduct and contributor guide.